### PR TITLE
Minor change due depreciation of 'Orchard.jQuery' module

### DIFF
--- a/Module.txt
+++ b/Module.txt
@@ -26,7 +26,7 @@ Features:
 		Name: OShop Shopping Cart
 		Category: Commerce
         Description: Provides shopping Cart service.
-		Dependencies: OShop, Orchard.jQuery
+		Dependencies: OShop, Orchard.Resources
 	OShop.Locations:
 		Name: OShop Locations
 		Category: Commerce
@@ -41,7 +41,7 @@ Features:
 		Name: OShop Customers
 		Category: Commerce
         Description: Provides customer management.
-		Dependencies: OShop.Locations, Orchard.Users, Orchard.jQuery
+		Dependencies: OShop.Locations, Orchard.Users, Orchard.Resources
 	OShop.Checkout:
 		Name: OShop customer check-out
 		Category: Commerce


### PR DESCRIPTION
Both OShop.Customers and OShop.ShoppingCart modules depend on
'Orchard.jQuery' module, which seems to be depreciated. Changed the
dependencies to 'Orchard.Resources'.
